### PR TITLE
(HYD-380) Support namedtuple in PredictorsModule

### DIFF
--- a/hydrosdk/data/conversions.py
+++ b/hydrosdk/data/conversions.py
@@ -33,14 +33,16 @@ def python_dtype_to_proto(value, key, signature) -> TensorProto:
 
 def isinstance_namedtuple(obj) -> bool:
     """
-    based on https://stackoverflow.com/a/49325922/7127824 and https://github.com/Hydrospheredata/hydro-serving-sdk/pull/51
+    Based on https://stackoverflow.com/a/49325922/7127824 and https://github.com/Hydrospheredata/hydro-serving-sdk/pull/51
+    The main use is to check for namedtuples returned by pandas.DataFrame.itertuples()
 
     :param obj: any object
     :return: bool if object is an instance of namedtuple
     """
+
     return (isinstance(obj, tuple) and
-            getattr(obj, '_asdict', None) and
-            getattr(obj, '_fields', None))
+            hasattr(obj, '_asdict') and
+            hasattr(obj, '_fields'))
 
 
 def convert_inputs_to_tensor_proto(inputs, signature) -> dict:
@@ -71,6 +73,7 @@ def convert_inputs_to_tensor_proto(inputs, signature) -> dict:
         for key, value in dict(inputs).items():
             tensors[key] = numpy_data_to_tensor_proto(value.ravel(), value.dtype, value.shape)
     elif isinstance_namedtuple(inputs):
+        # also <class 'pandas.core.frame.Pandas'> goes here
         return convert_inputs_to_tensor_proto(inputs._asdict(), signature=signature)
     else:
         raise ValueError(

--- a/hydrosdk/data/conversions.py
+++ b/hydrosdk/data/conversions.py
@@ -57,6 +57,8 @@ def convert_inputs_to_tensor_proto(inputs, signature) -> dict:
     elif isinstance(inputs, pd.DataFrame):
         for key, value in dict(inputs).items():
             tensors[key] = numpy_data_to_tensor_proto(value.ravel(), value.dtype, value.shape)
+    elif callable(getattr(inputs, "_asdict", None)):
+        return convert_inputs_to_tensor_proto(inputs._asdict(), signature=signature)
     else:
         raise ValueError(
             "Conversion failed. Expected [pandas.DataFrame, dict[str, numpy.ndarray], dict[str, list], dict[str, python_primitive]], got {}".format(

--- a/tests/test-conversions.py
+++ b/tests/test-conversions.py
@@ -1,0 +1,16 @@
+from collections import namedtuple
+
+from hydrosdk.data.conversions import isinstance_namedtuple
+
+
+def test_isinstance_namedtuple_namedtuple():
+    Point = namedtuple('Point', ['x', 'y'])
+    pt = Point(1.0, 5.0)
+
+    assert isinstance_namedtuple(pt)
+
+
+def test_isinstance_namedtuple_tuple():
+    pt = (1, 2, 3)
+
+    assert not isinstance_namedtuple(pt)

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -1,5 +1,7 @@
 from collections import namedtuple
 
+import pandas as pd
+
 from hydrosdk.data.conversions import isinstance_namedtuple
 
 
@@ -14,3 +16,11 @@ def test_isinstance_namedtuple_tuple():
     pt = (1, 2, 3)
 
     assert not isinstance_namedtuple(pt)
+
+
+def test_isinstance_namedtuple_itertuples():
+    d = {'col1': [1, 2], 'col2': [3, 4]}
+    df = pd.DataFrame(data=d)
+
+    for row in df.itertuples():
+        assert isinstance_namedtuple(row)


### PR DESCRIPTION
I think it'd be great to support named tuples in predictors as they are the main type of objects produced during iteration on pandas Dataframes and hence play an important role in sending tabular data to Hydrosphere.

However, there is no such type as `namedtuple`, since `namedtuple()` is a factory method returns a new tuple subclass named `typename`.  There is no way to check it with `isinstance`, but we can check for callable attribute `_asdict` which is present in all namedtuples. 

I am not completely sure in this solution, wdy @KineticCookie @trthhrtz ? 

By doing so, we start supporting not only namedtuples, but all methods with `_asdict` function. 
We can add a check for having `tuple` class in bases to mitigate this.
