### PR TITLE
Add major entities to init scope

### DIFF
--- a/hydrosdk/__init__.py
+++ b/hydrosdk/__init__.py
@@ -8,4 +8,4 @@ from hydrosdk.contract import SignatureBuilder, ModelContract
 from hydrosdk.monitoring import MetricSpec, MetricSpecConfig, TresholdCmpOp
 
 
-__version__ = importlib_metadata.version("sagemaker")
+__version__ = importlib_metadata.version("hydrosdk")

--- a/hydrosdk/__init__.py
+++ b/hydrosdk/__init__.py
@@ -1,1 +1,11 @@
-from hydrosdk.data.types import scalar
+import importlib_metadata
+
+from hydrosdk.modelversion import LocalModel,  ModelVersion
+from hydrosdk.image import DockerImage
+from hydrosdk.application import Application
+from hydrosdk.cluster import Cluster
+from hydrosdk.contract import SignatureBuilder, ModelContract
+from hydrosdk.monitoring import MetricSpec, MetricSpecConfig, TresholdCmpOp
+
+
+__version__ = importlib_metadata.version("sagemaker")

--- a/hydrosdk/__init__.py
+++ b/hydrosdk/__init__.py
@@ -1,6 +1,6 @@
 import importlib_metadata
 
-from hydrosdk.modelversion import LocalModel,  ModelVersion
+from hydrosdk.modelversion import LocalModel, ModelVersion
 from hydrosdk.image import DockerImage
 from hydrosdk.application import Application
 from hydrosdk.cluster import Cluster

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ pkgs = find_packages(exclude=['tests', 'tests.*'])
 print("FOUND PKGS", pkgs)
 
 reqs = [
+    'importlib_metadata~=1.7.0',
     'hydro-serving-grpc~=2.2.1',
     'sseclient-py~=1.7',
     'numpy~=1.18.3',
@@ -29,6 +30,10 @@ setup(
     url="https://hydrosphere.io/",
     license="Apache 2.0",
     packages=pkgs,
+    classifiers=["License :: OSI Approved :: Apache Software License",
+                 "Intended Audience :: Developers",
+                 "Intended Audience :: Information Technology",
+                 "Topic :: Software Development :: Libraries :: Python Modules"],
     install_requires=reqs,
     include_package_data=True,
     setup_requires=['pytest-runner'],


### PR DESCRIPTION
I suggest extending `__init__.py` so we can go from multiple imports statements

```py
from hydrosdk.modelversion import ModelVersion, LocalModel
from hydrosdk.application import Application
from hydrosdk.cluster import Clustter
```
to single line import statement
```py
import hydrosdk as hs
hs.Cluster(...)
hs.ModelVersion(...)
....
```