### PR TITLE
Timeout for grpc_server_on method

### DIFF
--- a/hydrosdk/utils.py
+++ b/hydrosdk/utils.py
@@ -1,5 +1,7 @@
 import grpc
 
+ALLOWED_TIMEOUT_gRPC_SECONDS = 5
+
 
 def grpc_server_on(channel: grpc.Channel) -> bool:
     """
@@ -10,7 +12,7 @@ def grpc_server_on(channel: grpc.Channel) -> bool:
     :return: status bool
     """
     try:
-        grpc.channel_ready_future(channel).result()
+        grpc.channel_ready_future(channel).result(ALLOWED_TIMEOUT_gRPC_SECONDS)
         return True
     except grpc.FutureTimeoutError:
         return False


### PR DESCRIPTION
I've added a timeout to the `grpc_server_on` method, so it would raise a `FutureTimeoutError` if there is no connection to a gRPC server.

Previously there was no timeout specified, so `grpc.channel_ready_future(channel).result()` was waiting for a result forever, without raising any exception ever.