### PR TITLE
Backport DeploymentConfiguration module to Python 3.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pandas~=1.0.3
 sseclient==0.0.26
 requests_mock>=1.7.0
 pytest~=5.4.1
+dataclasses==0.7

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ reqs = [
     'pandas~=1.0.3',
     'pyyaml~=5.3.1',
     'requests~=2.23.0',
+    'dataclasses==0.7',
     'requests_toolbelt~=0.9.1'
 ]
 


### PR DESCRIPTION
DeploymentConfiguration features a `dataclasses` and `typing` modules, standard in Python 3.7. They are completely\partially unavailable in Python 3.6 which is unfortunate since half of the developers still use Python 3.6. 

I'd added compatibility with it via PyPi `dataclasses` backport library and removing `_GenericAlias` used in `typing` library, which is available only in Python 3.7.