### PR TITLE
Added Documentation Building to Jenkins

### DIFF
--- a/docs/docs-src/requirements.txt
+++ b/docs/docs-src/requirements.txt
@@ -1,0 +1,3 @@
+Sphinx==3.2.1
+recommonmark==0.6.0
+sphinx-rtd-theme==0.5.0

--- a/jenkinsfile.groovy
+++ b/jenkinsfile.groovy
@@ -1,5 +1,20 @@
 def repository = 'hydro-serving-sdk'
 
+def buildAndPushDocs = {
+ sh """#!/bin/bash
+    python3 -m venv docs_venv
+    source docs_venv/bin/activate
+    python setup.py install
+    pip install -r docs/docs-src requirements.txt
+    make -C docs/docs-src github
+    git add docs/*
+    git commit -m "Documentation rebuilt"
+    git push
+    deactivate
+"""
+}
+
+
 def buildAndPublishReleaseFunction = {
     configFileProvider([configFile(fileId: 'PYPIDeployConfiguration', targetLocation: '.pypirc', variable: 'PYPI_SETTINGS')]) {
         sh """#!/bin/bash


### PR DESCRIPTION
Hi @KineticCookie, I've added missing dependencies required for building documentation and sketched a groovy function that builds and pushes built documentation to the repo. I'm not sure when I should call it or how to integrate it with a current `pipelineCommon`. Would you mind giving me a helping hand here?